### PR TITLE
fix Contao version requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php":">=5.6",
-        "contao/core-bundle":"~3.5 || ~4.3.9",
+        "contao/core-bundle":"^3.5.26 || ^4.3.9",
         "contao-community-alliance/composer-plugin":"~2.4 || ~3.0",
         "menatwork/contao-multicolumnwizard": "^3.3"
     },


### PR DESCRIPTION
There are two problems in the current `composer.json`:

## Wrong minimum Contao 3 version

Due to the usage of
```php
$GLOBALS['TL_LANG']['MSC']['cal_timeSeparator']
```
you need to specify a minimum Contao version of at least `3.5.26`, since that translation only exists since then.

## Restrictive minimum Contao 4 version

Due to the usage of
```
~4.3.9
```
this extension would not be installable on  Contao `4.4.x` or higher.